### PR TITLE
Handle multiple views registered by Phoenix 1.7

### DIFF
--- a/lib/bureaucrat/type_collector.ex
+++ b/lib/bureaucrat/type_collector.ex
@@ -8,6 +8,12 @@ defmodule Bureaucrat.TypeCollector do
     Agent.start_link(fn -> %__MODULE__{} end, name: __MODULE__)
   end
 
+  def register_types(modules) when is_map(modules) do
+    for module <- Map.values(modules) do
+      register_types(module)
+    end
+  end
+
   def register_types(module) do
     Agent.update(__MODULE__, fn state ->
       do_register_types(module, state)


### PR DESCRIPTION
Phoenix 1.7 allows multiple views to be assigned.
The incoming modules are now a map, with the value as the module name.

See:
https://github.com/phoenixframework/phoenix/blob/7a0db89e71e532564d3d44e88fadab88971a16ed/lib/phoenix/controller.ex#LL539C1-L539C1